### PR TITLE
Fix passing of arguments

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,8 @@ LABEL repository="https://github.com/dependency-check/Dependency-Check_Action" \
 
 USER root 
 
+RUN apk add bash
+
 COPY entrypoint.sh /entrypoint.sh
-RUN chmod +x /entrypoint.sh
-ENTRYPOINT ["/bin/sh","/entrypoint.sh"]
+
+ENTRYPOINT ["/bin/bash", "/entrypoint.sh"]

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,4 +1,3 @@
 #!/bin/bash
 set -e
-all_args=$@
-/usr/share/dependency-check/bin/dependency-check.sh  ${all_args} 
+/usr/share/dependency-check/bin/dependency-check.sh "${@:1:$#-1}" ${!#}

--- a/readme.md
+++ b/readme.md
@@ -42,7 +42,7 @@ jobs:
           path: '.'
           format: 'HTML'
           out: 'reports' # this is the default, no need to specify unless you wish to override it
-          args: >
+          args: >-
             --failOnCVSS 7
             --enableRetired
       - name: Upload Test results


### PR DESCRIPTION
Arguments are now passed safely to the dependency-check process.

E.g., this fixes some issues with project names containing white spaces. Probably also a fix for #13 .

I use `bash` to better work with arrays, so that the passing of `args` still works as before. Also note the shebang in `entrypoint.sh`.