### PR TITLE
Fix `readme.md` formatting

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -58,7 +58,6 @@ When used in conjunction with the GitHub Action [setup-java](https://github.com/
 This is due to the environment variable `JAVA_HOME` being changed by the setup-java GitHub Action. To fix this problem you will need to reset `JAVA_HOME` to match how it's being set in the image [Dependency-Check Docker Image](https://github.com/jeremylong/DependencyCheck/blob/main/Dockerfile#L16) within the Depcheck step. 
 
 Example:
-```
 ```yaml
 ...
 - name: Depcheck


### PR DESCRIPTION
The code block in https://github.com/dependency-check/Dependency-Check_Action#error-java_home-is-not-defined-correctly is not correctly formatted.